### PR TITLE
Ensure text effects are applied before showing the initial text on a state change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "waybar-module-music"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waybar-module-music"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "MPRIS music module for Waybar"
 license = "GPL3"

--- a/dist/arch/PKGBUILD
+++ b/dist/arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=waybar-module-music-git
-pkgver=0.1.3_r139.733ed2f
+pkgver=0.1.4_r147.9e2495d
 pkgrel=1
 pkgdesc='A Waybar module to show & control the current MPRIS media players state'
 arch=('x86_64')

--- a/src/services/display.rs
+++ b/src/services/display.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 
+#[derive(Debug)]
 enum DisplayMessages {
     PlayerStateChanged(PlayerState),
     AnimationDue,
@@ -183,6 +184,8 @@ impl Display {
                 }
             };
 
+            debug!("msg receieved: {:?}", msg);
+
             match msg {
                 DisplayMessages::PlayerStateChanged(state) => {
                     if let Some(player_state) = player_state {
@@ -211,11 +214,14 @@ impl Display {
                             "player",
                         );
                     }
+                    player_state = Some(state);
+                    fields.iter_mut().for_each(|(_, v)| {
+                        v.should_redraw();
+                    });
+                    self.draw(&player_state, &mut fields);
                     if let Err(err) = effect_tx.send(self.should_effects_be_redrawn(&fields)) {
                         error!("failed to notify effects thread: {err}");
                     }
-                    player_state = Some(state);
-                    self.draw(&player_state, &mut fields)
                 }
                 DisplayMessages::AnimationDue => {
                     if self.should_effects_be_redrawn(&fields) {


### PR DESCRIPTION
Previously, the original text pre-effect would show for a split second before the effects had a chance to apply.