### PR TITLE
Marquee breaks on certain symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -441,7 +441,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "waybar-module-music"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waybar-module-music"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "MPRIS music module for Waybar"
 license = "GPL3"
@@ -15,7 +15,7 @@ panic = "abort"
 
 [dependencies]
 bincode = "2.0.1"
-clap = { version = "4.5.40", features = ["derive"] }
+clap = { version = "4.5.41", features = ["derive"] }
 dbus = "0.9.7"
 dirs = "6.0.0"
 log = "0.4.27"

--- a/src/effects/text_effect.rs
+++ b/src/effects/text_effect.rs
@@ -48,7 +48,15 @@ impl TextEffect {
         self.last_drawn = text;
     }
 
+    // waybar is not able to display unescaped quotation marks
+    // FIXME: the width of the output changes in waybar even with this, for some reason
+    fn sanitize_output(&self, value: &str) -> String {
+        value.replace("\"", "\\\"")
+    }
+
     pub fn draw(&mut self, text: &str) -> String {
+        let text = self.sanitize_output(text);
+
         if self.last_drawn.is_empty() {
             self.last_drawn = text.to_string();
         }

--- a/src/services/display.rs
+++ b/src/services/display.rs
@@ -307,13 +307,13 @@ impl Display {
             }
         };
 
-        println!(
-            "{}",
-            self.format_json_output(
-                &self.populate_using_placeholders(player_state, fields),
-                self.get_class(player_state)
-            )
-        )
+        let output = self.format_json_output(
+            &self.populate_using_placeholders(player_state, fields),
+            self.get_class(player_state),
+        );
+
+        // debug!("{output}");
+        println!("{output}")
     }
 }
 


### PR DESCRIPTION
Handle cases where the output contains ", which causes issues with waybar's output.