### PR TITLE
Pin rust toolchain for reproducible Nix builds (fix upstream manifest drift)

### DIFF
--- a/nix/rust-toolchain.nix
+++ b/nix/rust-toolchain.nix
@@ -10,7 +10,7 @@ _: {
     options.waybar-module-music.rust-toolchain = mkOption {
       default = fenix.packages.fromToolchainFile {
         file = ../rust-toolchain.toml;
-        sha256 = "sha256-SDu4snEWjuZU475PERvu+iO50Mi39KVjqCeJeNvpguU=";
+        sha256 = "sha256-vra6TkHITpwRyA5oBKAHSX0Mi6CBDNQD+ryPSpxFsfg=";
       };
       type = types.package;
       description = "The rust Toolchain we Use";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,5 @@
-#NOTE: whenever you update this file, please make sure to rerun `nix develop`
-# and look at the error. It will immediately tell you that the hash no longer
-# matches.
-# if that is the case, just copy the sha256 from the error and put it into nix/rust-toolchain.nix.
-# When rerunning now, there should no longer be an error.
 [toolchain]
-channel = "stable"
+channel = "1.93.0"
 components = [
     "rustc",
     "cargo",


### PR DESCRIPTION
Problem

Our Nix build occasionally fails during the rust toolchain setup phase with “manifest fetching” that leads to hash mismatch.
This happens because we rely on a moving target toolchain (stable) and fenix.fromToolchainFile resolves it via the upstream rustup manifest, which changes over time.
So the build can break out of nowhere.

Solution
Pin the Rust toolchain to an immutable identifier: use a specific Rust release x.y.z in rust-toolchain.toml

And as a result Nix builds become fully reproducible and no longer break due to upstream manifest drift. 
Toolchain upgrades remain easy, but become a dedicated PR on demand.