### PR TITLE
Add unicode grapheme support to ellipsis and marquee effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +537,7 @@ dependencies = [
  "serde",
  "simplelog",
  "toml",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ log = "0.4.29"
 serde = { version = "1.0.228", features = ["serde_derive", "derive"] }
 simplelog = "0.12.2"
 toml = "0.9.11"
+unicode-segmentation = "1.13.2"

--- a/src/effects/ellipsis.rs
+++ b/src/effects/ellipsis.rs
@@ -28,6 +28,8 @@ impl Effect for Ellipsis {
         self.active = false;
         format!(
             "{}...",
+            // we gotta join here, since we have a Vec<&str>, not a string.
+            // and join just looks nicer than .into_iter().collect<String>() but is functionally identical
             text_graphemes.split_at(self.max_width as usize).0.join("")
         )
     }

--- a/src/effects/ellipsis.rs
+++ b/src/effects/ellipsis.rs
@@ -1,3 +1,5 @@
+use unicode_segmentation::UnicodeSegmentation;
+
 use super::effect::Effect;
 
 pub struct Ellipsis {
@@ -18,12 +20,16 @@ impl Ellipsis {
 
 impl Effect for Ellipsis {
     fn apply(&mut self, text: String) -> String {
-        if text.len() <= self.max_width as usize || self.max_width == 0 {
+        let text_graphemes = text.graphemes(true).collect::<Vec<&str>>();
+        if text_graphemes.len() <= self.max_width as usize || self.max_width == 0 {
             return text;
         }
 
         self.active = false;
-        format!("{}...", text.split_at(self.max_width as usize).0)
+        format!(
+            "{}...",
+            text_graphemes.split_at(self.max_width as usize).0.join("")
+        )
     }
 
     fn is_active(&self) -> bool {

--- a/src/effects/marquee.rs
+++ b/src/effects/marquee.rs
@@ -1,4 +1,6 @@
-use std::time::Instant;
+use unicode_segmentation::UnicodeSegmentation;
+
+use std::{ops::Deref, time::Instant};
 
 use super::effect::Effect;
 
@@ -27,17 +29,22 @@ impl Marquee {
 }
 
 impl Effect for Marquee {
-    fn apply(&mut self, mut text: String) -> String {
-        if text.len() <= self.max_width as usize || self.max_width == 0 {
+    fn apply(&mut self, text: String) -> String {
+        let mut text_graphemes = text.graphemes(true).collect::<Vec<&str>>();
+        if text_graphemes.len() <= self.max_width as usize || self.max_width == 0 {
             return text;
         }
 
-        text.push_str(PADDING);
+        let mut padding_graphemes = PADDING.graphemes(true).collect::<Vec<_>>();
+        text_graphemes.append(&mut padding_graphemes);
 
-        let mut result = String::new();
-        for i in self.current_pos..self.current_pos + text.len() as u16 {
-            let i = i % text.len() as u16;
-            let c = text.chars().nth((i) as usize).unwrap_or(' ');
+        let mut result = Vec::new();
+        for i in self.current_pos..self.current_pos + text_graphemes.len() as u16 {
+            let i = i % text_graphemes.len() as u16;
+            let c = text_graphemes
+                .get((i) as usize)
+                .map(Deref::deref)
+                .unwrap_or(" ");
             result.push(c);
         }
 
@@ -53,7 +60,7 @@ impl Effect for Marquee {
 
         if self.instant.is_none() {
             self.current_pos += 1;
-            self.current_pos %= text.len() as u16;
+            self.current_pos %= text_graphemes.len() as u16;
         }
 
         if self.instant.is_none() && self.pause_on_loop_ms != 0 && self.current_pos == 0 {
@@ -62,11 +69,12 @@ impl Effect for Marquee {
 
         if result.len() > self.max_width as usize {
             result
-                .chars()
+                .iter()
                 .take(self.max_width as usize)
+                .map(Deref::deref)
                 .collect::<String>()
         } else {
-            result
+            result.join("")
         }
     }
 

--- a/src/effects/marquee.rs
+++ b/src/effects/marquee.rs
@@ -69,9 +69,8 @@ impl Effect for Marquee {
 
         if result.len() > self.max_width as usize {
             result
-                .iter()
+                .into_iter()
                 .take(self.max_width as usize)
-                .map(Deref::deref)
                 .collect::<String>()
         } else {
             result.join("")

--- a/src/effects/marquee.rs
+++ b/src/effects/marquee.rs
@@ -35,8 +35,11 @@ impl Effect for Marquee {
             return text;
         }
 
+        // this is a bit ugly but since we're not working with a string anymore it's necessary.
+        // NOTE: padding_graphemes is emptied by the append, so I'm dropping it manually.
         let mut padding_graphemes = PADDING.graphemes(true).collect::<Vec<_>>();
         text_graphemes.append(&mut padding_graphemes);
+        drop(padding_graphemes);
 
         let mut result = Vec::new();
         for i in self.current_pos..self.current_pos + text_graphemes.len() as u16 {


### PR DESCRIPTION
This effectively fixes #27 as best as possible. It adds the [unicode-segmentation](https://crates.io/crates/unicode-segmentation) crate, which already implements unicode grapheme handling. I tried implementing this with as few changes as i could make.

As i was testing the before and after of the ellipsis effect, I actually noticed that i had also fixed another bug with character handling. `String::chars` gives an iterator of the bytes, as i have already mentioned in #27. Rust, however, enforces valid graphemes when printing or serializing and since some graphemes span multiple bytes and we count bytes (String::len counts the amount of bytes in the String), we may actually print partial characters, leading to the thread panicking. looks like this: 
```
thread '<unnamed>' (274427) panicked at /nix/store/j9zzyx0y772w13mpjlgq4zm1n2vspq3a-rust-1.93.0/lib/rustlib/src/rust/library/core/src/str/mod.rs:833:21:
byte index 5 is not a char boundary; it is inside 'ッ' (bytes 3..6) of `ロックンロールは鳴り止まないっ`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes that bug as well, It now handles this without panic. 
This PR does NOT fix the bug mentioned in #27 perfectly however. Since the character width is different between japanese and latin characters, I cannot fix the residual scaling it does based on font differences. It does it a heck of a lot less tho, so this is a "good enough" type situation. The only way to fix this entirely would be to have a marquee that scrolls pixel perfect rather than character based.

here's a comparison. the dev version is running on the top, the current master version on the bottom. they are running at the same time and target the same music player and thus the same song. Both are also using the same settings `-t 10 --marquee` As you can see, the scaling effect is at least reduced by a lot.
<img width="1806" height="1439" alt="image" src="https://github.com/user-attachments/assets/ed087446-c7ef-4a22-8fbf-7579cdb1db4a" />
